### PR TITLE
feat(i18n): add internationalization support with locale files

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,3 +1,5 @@
+import './utils/i18n';
+
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 
 import Navigation from './navigation/index';

--- a/app.json
+++ b/app.json
@@ -24,6 +24,9 @@
     },
     "web": {
       "favicon": "./assets/favicon.png"
-    }
+    },
+    "plugins": [
+      "expo-localization"
+    ]
   }
 }

--- a/components/MoodPicker.js
+++ b/components/MoodPicker.js
@@ -1,15 +1,17 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import React, { useEffect, useState } from 'react';
 import { Text, TouchableOpacity, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
 
 import { moods } from '../constants/moods';
+import { MOOD_LIST_KEY } from '../constants/storage';
 import MoodPickerStyle from '../styles/components/MoodPicker';
 import MoodButton from './MoodButton';
-import {MOOD_LIST_KEY} from '../constants/storage'
 
 const MoodPicker = () => {
   const [selectedMood, setSelectedMood] = useState(null);
   const [moodList, setMoodList] = useState([]);
+  const { t } = useTranslation();
 
   const handleSave = async () => {
     if (!selectedMood) return;
@@ -24,7 +26,7 @@ const MoodPicker = () => {
     } catch (e) {
       console.error('Failed to save mood', e);
     }
-  }
+  };
 
   const loadMoods = async () => {
     try {
@@ -61,7 +63,7 @@ const MoodPicker = () => {
         onPress={handleSave}
         disabled={!selectedMood}
       >
-        <Text style={MoodPickerStyle.saveButtonText}>Save</Text>
+        <Text style={MoodPickerStyle.saveButtonText}>{t('button:save')}</Text>
       </TouchableOpacity>
     </View>
   );

--- a/constants/storage.js
+++ b/constants/storage.js
@@ -1,2 +1,1 @@
-
 export const MOOD_LIST_KEY = 'mood-list';

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,11 @@
         "@react-navigation/native": "^7.1.9",
         "@react-navigation/native-stack": "^7.3.13",
         "expo": "~53.0.8",
+        "expo-localization": "~16.1.5",
         "expo-status-bar": "~2.2.3",
+        "i18next": "^25.1.3",
         "react": "19.0.0",
+        "react-i18next": "^15.5.1",
         "react-native": "0.79.2",
         "react-native-safe-area-context": "5.4.0",
         "react-native-screens": "~4.10.0"
@@ -5224,6 +5227,19 @@
         "react": "*"
       }
     },
+    "node_modules/expo-localization": {
+      "version": "16.1.5",
+      "resolved": "https://registry.npmjs.org/expo-localization/-/expo-localization-16.1.5.tgz",
+      "integrity": "sha512-dymvf0S11afyMeRbnoXd2iWWzFYwg21jHTnLBO/7ObNO1rKlYpus0ghVDnh+sJFV2u7s518e/JTcAqNR69EZkw==",
+      "license": "MIT",
+      "dependencies": {
+        "rtl-detect": "^1.0.2"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*"
+      }
+    },
     "node_modules/expo-modules-autolinking": {
       "version": "2.1.10",
       "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-2.1.10.tgz",
@@ -6007,6 +6023,15 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
     },
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "license": "MIT",
+      "dependencies": {
+        "void-elements": "3.1.0"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -6040,6 +6065,37 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "25.1.3",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.1.3.tgz",
+      "integrity": "sha512-VY1iKox3YWPRTNMHFdgk5TV+Jq6rNKexLCLpPmP5oXXJ5Kl7yDBi3ycZ5fyEKZ1tNBW5gOqD4WV0XqE7rl3JUg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.1"
+      },
+      "peerDependencies": {
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/iconv-lite": {
@@ -8801,6 +8857,32 @@
         "react": ">=17.0.0"
       }
     },
+    "node_modules/react-i18next": {
+      "version": "15.5.1",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-15.5.1.tgz",
+      "integrity": "sha512-C8RZ7N7H0L+flitiX6ASjq9p5puVJU1Z8VyL3OgM/QOMRf40BMZX+5TkpxzZVcTmOLPX5zlti4InEX5pFyiVeA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.25.0",
+        "html-parse-stringify": "^3.0.1"
+      },
+      "peerDependencies": {
+        "i18next": ">= 23.2.3",
+        "react": ">= 16.8.0",
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
@@ -9254,6 +9336,12 @@
       "engines": {
         "node": ">= 18"
       }
+    },
+    "node_modules/rtl-detect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/rtl-detect/-/rtl-detect-1.1.2.tgz",
+      "integrity": "sha512-PGMBq03+TTG/p/cRB7HCLKJ1MgDIi07+QU1faSjiYRfmY5UsAttV9Hs08jDAHVwcOwmVLcSJkpwyfXszVjWfIQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/safe-array-concat": {
       "version": "1.1.3",
@@ -10630,6 +10718,15 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/vlq/-/vlq-1.0.1.tgz",
       "integrity": "sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w=="
+    },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/walker": {
       "version": "1.0.8",
@@ -14767,6 +14864,14 @@
       "integrity": "sha512-wU9qOnosy4+U4z/o4h8W9PjPvcFMfZXrlUoKTMBW7F4pLqhkkP/5G4EviPZixv4XWFMjn1ExQ5rV6BX8GwJsWA==",
       "requires": {}
     },
+    "expo-localization": {
+      "version": "16.1.5",
+      "resolved": "https://registry.npmjs.org/expo-localization/-/expo-localization-16.1.5.tgz",
+      "integrity": "sha512-dymvf0S11afyMeRbnoXd2iWWzFYwg21jHTnLBO/7ObNO1rKlYpus0ghVDnh+sJFV2u7s518e/JTcAqNR69EZkw==",
+      "requires": {
+        "rtl-detect": "^1.0.2"
+      }
+    },
     "expo-modules-autolinking": {
       "version": "2.1.10",
       "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-2.1.10.tgz",
@@ -15318,6 +15423,14 @@
         }
       }
     },
+    "html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "requires": {
+        "void-elements": "3.1.0"
+      }
+    },
     "http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -15344,6 +15457,14 @@
       "requires": {
         "agent-base": "^7.1.2",
         "debug": "4"
+      }
+    },
+    "i18next": {
+      "version": "25.1.3",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.1.3.tgz",
+      "integrity": "sha512-VY1iKox3YWPRTNMHFdgk5TV+Jq6rNKexLCLpPmP5oXXJ5Kl7yDBi3ycZ5fyEKZ1tNBW5gOqD4WV0XqE7rl3JUg==",
+      "requires": {
+        "@babel/runtime": "^7.27.1"
       }
     },
     "iconv-lite": {
@@ -17203,6 +17324,15 @@
       "integrity": "sha512-r4F0Sec0BLxWicc7HEyo2x3/2icUTrRmDjaaRyzzn+7aDyFZliszMDOgLVwSnQnYENOlL1o569Ze2HZefk8clA==",
       "requires": {}
     },
+    "react-i18next": {
+      "version": "15.5.1",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-15.5.1.tgz",
+      "integrity": "sha512-C8RZ7N7H0L+flitiX6ASjq9p5puVJU1Z8VyL3OgM/QOMRf40BMZX+5TkpxzZVcTmOLPX5zlti4InEX5pFyiVeA==",
+      "requires": {
+        "@babel/runtime": "^7.25.0",
+        "html-parse-stringify": "^3.0.1"
+      }
+    },
     "react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
@@ -17537,6 +17667,11 @@
         "parseurl": "^1.3.3",
         "path-to-regexp": "^8.0.0"
       }
+    },
+    "rtl-detect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/rtl-detect/-/rtl-detect-1.1.2.tgz",
+      "integrity": "sha512-PGMBq03+TTG/p/cRB7HCLKJ1MgDIi07+QU1faSjiYRfmY5UsAttV9Hs08jDAHVwcOwmVLcSJkpwyfXszVjWfIQ=="
     },
     "safe-array-concat": {
       "version": "1.1.3",
@@ -18519,6 +18654,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/vlq/-/vlq-1.0.1.tgz",
       "integrity": "sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w=="
+    },
+    "void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w=="
     },
     "walker": {
       "version": "1.0.8",

--- a/package.json
+++ b/package.json
@@ -19,10 +19,13 @@
     "@react-navigation/native-stack": "^7.3.13",
     "expo": "~53.0.8",
     "expo-status-bar": "~2.2.3",
+    "i18next": "^25.1.3",
     "react": "19.0.0",
+    "react-i18next": "^15.5.1",
     "react-native": "0.79.2",
     "react-native-safe-area-context": "5.4.0",
-    "react-native-screens": "~4.10.0"
+    "react-native-screens": "~4.10.0",
+    "expo-localization": "~16.1.5"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/screens/HistoryScreen.js
+++ b/screens/HistoryScreen.js
@@ -1,12 +1,12 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import React, { useCallback, useState } from 'react';
-import { FlatList,Text, View } from 'react-native';
-import {sg} from '../styling'
-import { useSafeAreaInsets } from "react-native-safe-area-context";
-import MoodCard from '../components/MoodCard';
-import {MOOD_LIST_KEY} from '../constants/storage'
 import { useFocusEffect } from '@react-navigation/native';
+import React, { useCallback, useState } from 'react';
+import { FlatList, Text, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
+import MoodCard from '../components/MoodCard';
+import { MOOD_LIST_KEY } from '../constants/storage';
+import { sg } from '../styling';
 
 const HistoryScreen = () => {
   const insets = useSafeAreaInsets();
@@ -32,15 +32,19 @@ const HistoryScreen = () => {
   );
 
   return (
-    <View style={[sg.flex,{paddingTop:insets.top}]} >
-      {!moodList.length ? <Text>No history yet</Text> : <FlatList
-        data={moodList}
-        keyExtractor={(item) => item.id.toString()}
-        renderItem={({ item }) => <MoodCard item={item} />}
-        style={{ marginTop: 20 }}
-        contentContainerStyle={{ paddingBottom: 100 }}
-        showsVerticalScrollIndicator={false}
-      />}
+    <View style={[sg.flex, { paddingTop: insets.top }]}>
+      {!moodList.length ? (
+        <Text>No history yet</Text>
+      ) : (
+        <FlatList
+          data={moodList}
+          keyExtractor={(item) => item.id.toString()}
+          renderItem={({ item }) => <MoodCard item={item} />}
+          style={{ marginTop: 20 }}
+          contentContainerStyle={{ paddingBottom: 100 }}
+          showsVerticalScrollIndicator={false}
+        />
+      )}
     </View>
   );
 };

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -1,13 +1,14 @@
 import React from 'react';
-import { Text, View } from 'react-native';
-import {sg} from '../styling'
-import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
 import MoodPicker from '../components/MoodPicker';
+import { sg } from '../styling';
 
 const HomeScreen = () => {
   const insets = useSafeAreaInsets();
   return (
-    <View style={[sg.flex,sg.aICenter,sg.jCCenter,{paddingTop:insets.top}]} >
+    <View style={[sg.flex, sg.aICenter, sg.jCCenter, { paddingTop: insets.top }]}>
       <MoodPicker />
     </View>
   );

--- a/screens/MoodScreen.js
+++ b/screens/MoodScreen.js
@@ -1,4 +1,4 @@
-import { View, Text } from 'react-native';
+import { Text, View } from 'react-native';
 
 import ScreenView from '../components/ScreenView';
 import layout from '../styles/general/layout';

--- a/utils/i18n/index.js
+++ b/utils/i18n/index.js
@@ -1,0 +1,23 @@
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+import * as Localization from 'expo-localization';
+
+import en from './locales/en.js';
+import ua from './locales/ua.js';
+
+const resources = {
+  en,
+  ua,
+};
+
+i18n.use(initReactI18next).init({
+  resources,
+  lng: Localization.getLocales()[0].languageCode,
+  fallbackLng: 'en',
+  interpolation: { escapeValue: false },
+  react: {
+    useSuspense: true,
+  },
+});
+
+export default i18n;

--- a/utils/i18n/locales/en.js
+++ b/utils/i18n/locales/en.js
@@ -1,0 +1,9 @@
+export default {
+  route:{
+    home:"Home",
+    history:"History",
+  },
+  button: {
+    save: "Save",
+  }
+};

--- a/utils/i18n/locales/ua.js
+++ b/utils/i18n/locales/ua.js
@@ -1,0 +1,9 @@
+export default {
+  route: {
+    home: "Домашня",
+    history: "Історія",
+  },
+  button: {
+    save: "Зберегти",
+  }
+};


### PR DESCRIPTION
_**This PR introduces full internationalization (i18n) support across the app:**_

**Locale Files**
Extracted all UI strings into separate en.js and ua.js under utils/i18n/locales/
Centralized translations in utils/i18n/index.js using i18next and react-i18next

**Language Detection & Fallback**
Automatically picks up device language via expo-localization
Falls back to English if the locale isn’t supported

**Component Integration**
Wrapped the app entry point to initialize i18n before rendering (import './utils/i18n';)
Updated MoodPicker, navigation labels, buttons, etc. to use the t('key') lookup

**Ready for Expansion**
Easily add new languages by dropping in additional locale files
Components remain clean—no hard-coded strings