### PR TITLE
feat(register): add registration form with validation and i18n support

### DIFF
--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -37,7 +37,7 @@ export class AuthStore {
       await createUserWithEmailAndPassword(auth, email, password);
     } catch (err: any) {
       runInAction(() => {
-        this.error = err.message;
+        this.error = handleFirebaseError(err);
       });
     } finally {
       runInAction(() => {

--- a/src/utils/i18n/locales/en.ts
+++ b/src/utils/i18n/locales/en.ts
@@ -9,9 +9,12 @@ export default {
     forgotPassword: 'Forgot your password?',
     noAccount: "Don't have an account?",
     register: 'Register',
+    confirmPassword: 'Confirm Password',
+    confirmPasswordPlaceholder: 'Confirm your password',
+    accountCreated: 'Your account has been created',
   },
   validation: {
-    required: 'This field is required',
+    requiredEmail: "Email is required",
     requiredPassword: 'Password is required',
     invalidEmail: 'Invalid email address',
     passwordMinLength: 'Password must be at least {{length}} characters',
@@ -20,7 +23,8 @@ export default {
     userNotFound: "User not found",
     wrongPassword: "Incorrect password",
     tooManyRequests: "Too many attempts. Please try again later.",
-    default: "An error occurred. Please try again."
+    default: "An error occurred. Please try again.",
+    passwordsDoNotMatch: 'Passwords do not match',
   },
   route: {
     home: 'Home',

--- a/src/utils/i18n/locales/ua.ts
+++ b/src/utils/i18n/locales/ua.ts
@@ -9,9 +9,12 @@ export default {
     forgotPassword: 'Забули пароль?',
     noAccount: 'Немає акаунта?',
     register: 'Зареєструватись',
+    confirmPassword: 'Підтвердження пароля',
+    confirmPasswordPlaceholder: 'Повторіть пароль',
+    accountCreated: 'Ваш акаунт створено',
   },
   validation: {
-    required: 'Це поле є обовʼязковим',
+    requiredEmail: "Електронна пошта обов’язкова",
     requiredPassword: 'Пароль є обовʼязковим',
     invalidEmail: 'Невірна email адреса',
     passwordMinLength: 'Пароль має містити щонайменше {{length}} символів',
@@ -20,7 +23,8 @@ export default {
     userNotFound: "Користувача не знайдено",
     wrongPassword: "Невірний пароль",
     tooManyRequests: "Забагато спроб. Спробуйте пізніше.",
-    default: "Сталася помилка. Спробуйте ще раз."
+    default: "Сталася помилка. Спробуйте ще раз.",
+    passwordsDoNotMatch: 'Паролі не співпадають',
   },
   route: {
     home: 'Домашня',


### PR DESCRIPTION
- Replaced local state with react-hook-form in RegisterScreen
- Implemented ControlledInput for all input fields
- Added form validation rules including password match check
- Displayed Firebase errors via ControlledInput warning prop
- Updated i18n translations (en, ua) for register screen and validation messages
- Used MobX authStore for handling registration flow
- Navigates to login screen after successful registration with success toast