### PR TITLE
feat(auth): add password reset form with validation and Firebase erro…

### DIFF
--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -73,7 +73,7 @@ export class AuthStore {
       await sendPasswordResetEmail(auth, email);
     } catch (err: any) {
       runInAction(() => {
-        this.error = err.message;
+        this.error = handleFirebaseError(err);
       });
     } finally {
       runInAction(() => {

--- a/src/utils/i18n/locales/en.ts
+++ b/src/utils/i18n/locales/en.ts
@@ -9,6 +9,10 @@ export default {
     forgotPassword: 'Forgot your password?',
     noAccount: "Don't have an account?",
     register: 'Register',
+    resetPassword: "Reset Password",
+    sendResetLink: "Send Reset Link",
+    resetSuccess: "Password reset link sent to your email",
+    backToLogin: "Back to Login"
   },
   validation: {
     required: 'This field is required',

--- a/src/utils/i18n/locales/ua.ts
+++ b/src/utils/i18n/locales/ua.ts
@@ -9,6 +9,10 @@ export default {
     forgotPassword: 'Забули пароль?',
     noAccount: 'Немає акаунта?',
     register: 'Зареєструватись',
+    resetPassword: "Скинути пароль",
+    sendResetLink: "Надіслати посилання для скидання",
+    resetSuccess: "Посилання для скидання паролю надіслано на вашу пошту",
+    backToLogin: "Повернутись до входу"
   },
   validation: {
     required: 'Це поле є обовʼязковим',


### PR DESCRIPTION
- Implemented reset password screen using ControlledInput and react-hook-form
- Added i18n translations for EN and UA (auth and validation sections)
- Integrated validation rules and Firebase error messages
- Displayed Firebase errors via input warning prop
- Preserved navigation link back to Login screen