### PR TITLE
feat(mood): load and save user-specific mood list based on UID

### DIFF
--- a/src/components/MoodPicker.tsx
+++ b/src/components/MoodPicker.tsx
@@ -17,7 +17,7 @@ const MoodPicker: React.FC<MoodPickerProps> = ({ onSelectMood }) => {
   const { moodStore, themeStore } = useStore();
   const { t } = useTranslation();
 
-  const theme = themeStore.theme;
+  const {colors} = themeStore.theme;
 
   const handleSave = async () => {
     if (!selectedMood) return;
@@ -50,15 +50,15 @@ const MoodPicker: React.FC<MoodPickerProps> = ({ onSelectMood }) => {
         style={[
           MoodPickerStyle.saveButton,
           {
-            backgroundColor: selectedMood ? theme.colors.primary : theme.colors.placeholder,
-            shadowColor: selectedMood ? theme.colors.primaryDark : 'transparent',
+            backgroundColor: selectedMood ? colors.primary : colors.placeholder,
+            shadowColor: selectedMood ? colors.primaryDark : 'transparent',
           },
           !selectedMood && { opacity: 0.6 },
         ]}
         onPress={handleSave}
         disabled={!selectedMood}
       >
-        <Text style={[MoodPickerStyle.saveButtonText, { color: theme.colors.textLight }]}>
+        <Text style={[MoodPickerStyle.saveButtonText, { color: colors.textLight }]}>
           {t('button.save')}
         </Text>
       </TouchableOpacity>

--- a/src/constants/storage.ts
+++ b/src/constants/storage.ts
@@ -1,4 +1,5 @@
 export const MOOD_LIST_KEY = 'mood-list';
+
 export const LANGUAGE_STORAGE_KEY = '@language';
 export const ONBOARDING_SHOWN_KEY = '@onboardingShown';
 export const THEME_STORAGE_KEY = '@app-theme';

--- a/src/screens/HistoryScreen.tsx
+++ b/src/screens/HistoryScreen.tsx
@@ -8,14 +8,17 @@ import MoodCard from '../components/MoodCard';
 import { useStore } from '../store/StoreProvider';
 import { sg } from '../styling';
 
-const HistoryScreen = () => {
+const HistoryScreen = observer(() => {
   const insets = useSafeAreaInsets();
-  const { moodStore } = useStore();
+  const { moodStore, authStore, themeStore } = useStore();
+  const {colors}=themeStore.theme
 
   useFocusEffect(
     useCallback(() => {
-      moodStore.loadMoods();
-    }, [moodStore])
+      if (authStore.user) {
+        moodStore.loadMoods();
+      }
+    }, [moodStore, authStore.user])
   );
 
   const { moodList } = moodStore;
@@ -24,7 +27,7 @@ const HistoryScreen = () => {
     <View style={[sg.flex, { paddingTop: insets.top }]}>
       {!moodList.length ? (
         <View style={[sg.center, sg.flex]}>
-          <Text style={sg.textCenter}>No history yet</Text>
+          <Text style={[sg.textCenter,{color:colors.text}]}>No history yet</Text>
         </View>
       ) : (
         <FlatList
@@ -38,6 +41,6 @@ const HistoryScreen = () => {
       )}
     </View>
   );
-};
+});
 
-export default observer(HistoryScreen);
+export default HistoryScreen;

--- a/src/storage/moodStorage.ts
+++ b/src/storage/moodStorage.ts
@@ -1,19 +1,24 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { MOOD_LIST_KEY } from '../constants/storage';
-import { getTodayDate } from '../utils/date';
-import { sortByDateDesc } from '../utils/date';
+import { getTodayDate, sortByDateDesc } from '../utils/date';
 import { MoodItem } from '../components/MoodCard';
+import { MOOD_LIST_KEY } from '../constants/storage';
 
-export const saveTodayMoodItem = async (newMood: MoodItem): Promise<MoodItem[]> => {
+export const getMoodKey = (uid: string) => `${MOOD_LIST_KEY}-${uid}`;
+
+export const saveTodayMoodItem = async (
+  uid: string,
+  newMood: MoodItem
+): Promise<MoodItem[]> => {
   try {
+    const key = getMoodKey(uid);
     const today = getTodayDate();
-    const existing = await AsyncStorage.getItem(MOOD_LIST_KEY);
+    const existing = await AsyncStorage.getItem(key);
     const parsed: MoodItem[] = existing ? JSON.parse(existing) : [];
 
-    const filtered = parsed.filter(item => item.date.split('T')[0] !== today);
+    const filtered = parsed.filter((item) => item.date.split('T')[0] !== today);
     const updated = sortByDateDesc([newMood, ...filtered]);
 
-    await AsyncStorage.setItem(MOOD_LIST_KEY, JSON.stringify(updated));
+    await AsyncStorage.setItem(key, JSON.stringify(updated));
     return updated;
   } catch (error) {
     console.warn('Error saving mood:', error);
@@ -21,17 +26,42 @@ export const saveTodayMoodItem = async (newMood: MoodItem): Promise<MoodItem[]> 
   }
 };
 
-export const getTodayMood = async (): Promise<MoodItem | null> => {
+export const getTodayMood = async (uid: string): Promise<MoodItem | null> => {
   try {
-    const existing = await AsyncStorage.getItem(MOOD_LIST_KEY);
+    const key = getMoodKey(uid);
+    const existing = await AsyncStorage.getItem(key);
     if (!existing) return null;
 
     const moodList: MoodItem[] = JSON.parse(existing);
     const today = getTodayDate();
 
-    return moodList.find(item => item.date.split('T')[0] === today) ?? null;
+    return moodList.find((item) => item.date.split('T')[0] === today) ?? null;
   } catch (error) {
     console.warn('Error loading mood:', error);
     return null;
+  }
+};
+
+export const loadUserMoods = async (uid: string): Promise<MoodItem[]> => {
+  try {
+    const key = getMoodKey(uid);
+    const stored = await AsyncStorage.getItem(key);
+    if (stored) {
+      const parsed: MoodItem[] = JSON.parse(stored);
+      return sortByDateDesc(parsed);
+    }
+    return [];
+  } catch (e) {
+    console.error('Failed to load moods', e);
+    return [];
+  }
+};
+
+export const clearUserMoods = async (uid: string) => {
+  try {
+    const key = getMoodKey(uid);
+    await AsyncStorage.removeItem(key);
+  } catch (e) {
+    console.warn('Failed to clear moods', e);
   }
 };

--- a/src/store/RootStore.ts
+++ b/src/store/RootStore.ts
@@ -8,9 +8,8 @@ export class RootStore {
   authStore: AuthStore;
 
   constructor() {
-    this.moodStore = new MoodStore();
     this.themeStore = new ThemeStore();
     this.authStore = new AuthStore();
+    this.moodStore = new MoodStore(this);
   }
 }
-

--- a/src/store/moodStore.ts
+++ b/src/store/moodStore.ts
@@ -1,49 +1,57 @@
-import { makeAutoObservable, runInAction } from "mobx";
-import { saveTodayMoodItem } from "../storage/moodStorage";
-import AsyncStorage from "@react-native-async-storage/async-storage";
-import { MOOD_LIST_KEY } from "../constants/storage";
-import { MoodItem } from "../components/MoodCard";
-import { getTodayDate } from "../utils/date";
+import { makeAutoObservable, runInAction } from 'mobx';
+import { MoodItem } from '../components/MoodCard';
+import { getTodayDate } from '../utils/date';
+import { saveTodayMoodItem, loadUserMoods, clearUserMoods, getTodayMood } from '../storage/moodStorage';
+import { RootStore } from './RootStore';
 
 export class MoodStore {
+  root: RootStore;
   moodList: MoodItem[] = [];
 
-  constructor() {
+  constructor(root: RootStore) {
+    this.root = root;
     makeAutoObservable(this);
-    this.loadMoods();
   }
 
   async loadMoods() {
-    try {
-      const stored = await AsyncStorage.getItem(MOOD_LIST_KEY);
-      if (stored) {
-        const parsed: MoodItem[] = JSON.parse(stored);
-        parsed.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
-        runInAction(() => {
-          this.moodList = parsed;
-        });
-      }
-    } catch (e) {
-      console.error("Failed to load moods", e);
-    }
+    const uid = this.root.authStore.user?.uid;
+    if (!uid) return;
+
+    const moods = await loadUserMoods(uid);
+    runInAction(() => {
+      this.moodList = moods;
+    });
   }
 
   async saveMood(newMood: MoodItem) {
-    const updated = await saveTodayMoodItem(newMood);
+    const uid = this.root.authStore.user?.uid;
+    if (!uid) return;
+
+    const updated = await saveTodayMoodItem(uid, newMood);
     runInAction(() => {
       this.moodList = updated;
+    });
+  }
+
+  async getTodayMood() {
+    const uid = this.root.authStore.user?.uid;
+    if (!uid) return null;
+
+    return await getTodayMood(uid);
+  }
+
+  async clearMoods() {
+    const uid = this.root.authStore.user?.uid;
+    if (!uid) return;
+
+    await clearUserMoods(uid);
+    runInAction(() => {
+      this.moodList = [];
     });
   }
 
   get todayMood(): MoodItem | null {
     const today = getTodayDate();
     return this.moodList.find((item) => item.date.split("T")[0] === today) ?? null;
-  }
-
-  clearMoods() {
-    this.moodList = [];
-    AsyncStorage.removeItem(MOOD_LIST_KEY).catch((e) =>
-      console.warn("Failed to clear moods", e)
-    );
   }
 }


### PR DESCRIPTION
- Updated moodStore to use user UID from authStore
- Refactored mood storage methods to save/load mood list per user
- Replaced shared MOOD_LIST_KEY with dynamic key per UID
- Updated AppInitializer and HistoryScreen to support per-user mood data