### PR TITLE
feat(profile): add user profile photo upload and handling

### DIFF
--- a/app.json
+++ b/app.json
@@ -26,7 +26,13 @@
       "favicon": "./assets/favicon.png"
     },
     "plugins": [
-      "expo-localization"
+      "expo-localization",
+      [
+        "expo-image-picker",
+        {
+          "photosPermission": "The app accesses your photos to let you share them with your friends."
+        }
+      ]
     ],
     "entryPoint": "./index.tsx"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,8 @@
         "@react-navigation/native": "^7.1.9",
         "@react-navigation/native-stack": "^7.3.13",
         "expo": "~53.0.8",
+        "expo-image-manipulator": "~13.1.7",
+        "expo-image-picker": "~16.1.4",
         "expo-localization": "~16.1.5",
         "expo-status-bar": "~2.2.3",
         "firebase": "^11.8.1",
@@ -5968,6 +5970,39 @@
       "peerDependencies": {
         "expo": "*",
         "react": "*"
+      }
+    },
+    "node_modules/expo-image-loader": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-5.1.0.tgz",
+      "integrity": "sha512-sEBx3zDQIODWbB5JwzE7ZL5FJD+DK3LVLWBVJy6VzsqIA6nDEnSFnsnWyCfCTSvbGigMATs1lgkC2nz3Jpve1Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-image-manipulator": {
+      "version": "13.1.7",
+      "resolved": "https://registry.npmjs.org/expo-image-manipulator/-/expo-image-manipulator-13.1.7.tgz",
+      "integrity": "sha512-DBy/Xdd0E/yFind14x36XmwfWuUxOHI/oH97/giKjjPaRc2dlyjQ3tuW3x699hX6gAs9Sixj5WEJ1qNf3c8sag==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-image-loader": "~5.1.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-image-picker": {
+      "version": "16.1.4",
+      "resolved": "https://registry.npmjs.org/expo-image-picker/-/expo-image-picker-16.1.4.tgz",
+      "integrity": "sha512-bTmmxtw1AohUT+HxEBn2vYwdeOrj1CLpMXKjvi9FKSoSbpcarT4xxI0z7YyGwDGHbrJqyyic3I9TTdP2J2b4YA==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-image-loader": "~5.1.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-keep-awake": {
@@ -16378,6 +16413,28 @@
       "integrity": "sha512-d+xrHYvSM9WB42wj8vP9OOFWyxed5R1evphfDb6zYBmC1dA9Hf89FpT7TNFtj2Bk3clTnpmVqQTCYbbA2P3CLg==",
       "requires": {
         "fontfaceobserver": "^2.1.0"
+      }
+    },
+    "expo-image-loader": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-5.1.0.tgz",
+      "integrity": "sha512-sEBx3zDQIODWbB5JwzE7ZL5FJD+DK3LVLWBVJy6VzsqIA6nDEnSFnsnWyCfCTSvbGigMATs1lgkC2nz3Jpve1Q==",
+      "requires": {}
+    },
+    "expo-image-manipulator": {
+      "version": "13.1.7",
+      "resolved": "https://registry.npmjs.org/expo-image-manipulator/-/expo-image-manipulator-13.1.7.tgz",
+      "integrity": "sha512-DBy/Xdd0E/yFind14x36XmwfWuUxOHI/oH97/giKjjPaRc2dlyjQ3tuW3x699hX6gAs9Sixj5WEJ1qNf3c8sag==",
+      "requires": {
+        "expo-image-loader": "~5.1.0"
+      }
+    },
+    "expo-image-picker": {
+      "version": "16.1.4",
+      "resolved": "https://registry.npmjs.org/expo-image-picker/-/expo-image-picker-16.1.4.tgz",
+      "integrity": "sha512-bTmmxtw1AohUT+HxEBn2vYwdeOrj1CLpMXKjvi9FKSoSbpcarT4xxI0z7YyGwDGHbrJqyyic3I9TTdP2J2b4YA==",
+      "requires": {
+        "expo-image-loader": "~5.1.0"
       }
     },
     "expo-keep-awake": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,9 @@
     "react-native": "0.79.2",
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.10.0",
-    "react-native-toast-message": "^2.3.0"
+    "react-native-toast-message": "^2.3.0",
+    "expo-image-picker": "~16.1.4",
+    "expo-image-manipulator": "~13.1.7"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/src/utils/i18n/locales/en.ts
+++ b/src/utils/i18n/locales/en.ts
@@ -131,4 +131,10 @@ export default {
     },
     level:"Level {{level}}",
   },
+  errors: {
+    uploadPhotoFailed: "Failed to upload profile photo. Please try again.",
+    error: "Error",
+    uploadPhotoTooLarge: "The photo is too large (max 1MB)",
+    photoSaveFailed: "Failed to save photo. Please try again."
+  }
 };

--- a/src/utils/i18n/locales/uk.ts
+++ b/src/utils/i18n/locales/uk.ts
@@ -135,4 +135,10 @@ export default {
     },
     level: "Рівень {{level}}",
   },
+  errors: {
+    uploadPhotoFailed: "Не вдалося завантажити фото профілю. Спробуйте ще раз.",
+    error: "Помилка",
+    uploadPhotoTooLarge: "Фото завелике (максимум 1MB)",
+    photoSaveFailed: "Не вдалося зберегти фото."
+  }
 };


### PR DESCRIPTION
- Implement photo selection from gallery using expo-image-picker
- Resize and compress image before saving (300px width, 0.4 compression)
- Save photo as base64 string in Firestore with size validation
- Show localized toast messages for upload and save errors
- Update profile UI to display user photo or default avatar