### PR TITLE
refactor(profile): move avatar editing to EditProfileScreen

### DIFF
--- a/src/components/EditableAvatar.tsx
+++ b/src/components/EditableAvatar.tsx
@@ -15,8 +15,8 @@ const EditableAvatar = ({ uri, onPress, size = 100 }: Props) => {
   const { theme} = themeStore;
 
   return (
-    <Pressable onPress={onPress} style={{ width: size, height: size }}>
-      <View style={styles.container}>
+    <Pressable onPress={onPress} style={[styles.container,{ width: size, height: size }]}>
+      <View>
         <Image
           source={{ uri }}
           style={[
@@ -42,6 +42,7 @@ const styles = StyleSheet.create({
     position: 'relative',
     justifyContent: 'center',
     alignItems: 'center',
+    alignSelf:'center'
   },
   image: {
     resizeMode: 'cover',

--- a/src/screens/profile/EditProfileScreen.tsx
+++ b/src/screens/profile/EditProfileScreen.tsx
@@ -13,6 +13,10 @@ import { useStore } from '../../store/StoreProvider';
 import { showSuccessToast } from '../../utils/toast';
 import { getDisplayNameRules, getPhoneNumberRules } from '../../validation/rules';
 import { sg } from '../../styling';
+import EditableAvatar from '../../components/EditableAvatar';
+import * as ImagePicker from 'expo-image-picker';
+import Toast from 'react-native-toast-message';
+import { DEFAULT_AVATAR } from '../../constants/images';
 
 
 type FormValues = {
@@ -39,6 +43,30 @@ const EditProfileScreen = observer(() => {
     },
   });
 
+  const avatarSource = userProfile?.photoBase64
+  ? { uri: userProfile.photoBase64 }
+  : { uri: DEFAULT_AVATAR };
+
+  const handleChoosePhoto = async () => {
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ['images'],
+      allowsEditing: true,
+      quality: 0.8,
+    });
+
+    if (!result.canceled && result.assets?.[0]?.uri) {
+      try {
+        await authStore.uploadProfilePhoto(result.assets[0].uri, t);
+      } catch (err) {
+        Toast.show({
+          type: 'error',
+          text1: t('errors.error'),
+          text2: t('errors.uploadPhotoFailed'),
+        });
+      }
+    }
+  };
+
   const onSubmit = async (data: FormValues) => {
     await authStore.updateUserProfile(data);
 
@@ -54,6 +82,10 @@ const EditProfileScreen = observer(() => {
       <AppHeader showBack />
       <View style={styles.container}>
         <View>
+          <EditableAvatar
+            uri={avatarSource.uri}
+            onPress={handleChoosePhoto}
+          />
           <ControlledInput
           name="displayName"
           label={t('auth.displayName')}
@@ -85,7 +117,7 @@ const EditProfileScreen = observer(() => {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    paddingVertical: 24,
+    padding: 20,
     justifyContent:'space-between',
   },
 });

--- a/src/screens/profile/ProfileScreen.tsx
+++ b/src/screens/profile/ProfileScreen.tsx
@@ -3,23 +3,17 @@ import {
   View,
   Text,
   StyleSheet,
-  Image,
-  Pressable,
 } from 'react-native';
 import { observer } from 'mobx-react-lite';
 import { useNavigation } from '@react-navigation/native';
 import { useTranslation } from 'react-i18next';
-import * as ImagePicker from 'expo-image-picker';
-import Toast from 'react-native-toast-message';
 
 import AppHeader from '../../components/AppHeader';
 import ScreenView from '../../components/ScreenView';
 import { safeParseDate } from '../../utils/date';
 import { DEFAULT_AVATAR } from '../../constants/images';
 import UserInfoRow from '../../components/sections/UserInfoRow';
-import Button from '../../components/Button';
-import { MEDIUM } from '../../constants/types';
-import { sg } from '../../styling';
+
 import { EDIT_PROFILE_SCREEN } from '../../navigation/RouteNames';
 import { useStore } from '../../store/StoreProvider';
 import EditableAvatar from '../../components/EditableAvatar';
@@ -58,25 +52,6 @@ const ProfileScreen = observer(() => {
     ? t('profile.emailVerified')
     : t('profile.emailNotVerified');
 
-  const handleChoosePhoto = async () => {
-    const result = await ImagePicker.launchImageLibraryAsync({
-      mediaTypes: ['images'],
-      allowsEditing: true,
-      quality: 0.8,
-    });
-
-    if (!result.canceled && result.assets?.[0]?.uri) {
-      try {
-        await authStore.uploadProfilePhoto(result.assets[0].uri, t);
-      } catch (err) {
-        Toast.show({
-          type: 'error',
-          text1: t('errors.error'),
-          text2: t('errors.uploadPhotoFailed'),
-        });
-      }
-    }
-  };
 
   return (
     <ScreenView style={{ backgroundColor: theme.colors.background }}>
@@ -84,7 +59,7 @@ const ProfileScreen = observer(() => {
       <View style={styles.container}>
         <EditableAvatar
           uri={avatarSource.uri}
-          onPress={handleChoosePhoto}
+          onPress={() => navigation.navigate(EDIT_PROFILE_SCREEN as never)}
         />
 
         <Text style={[styles.name, { color: theme.colors.text }]}>{name}</Text>
@@ -97,13 +72,6 @@ const ProfileScreen = observer(() => {
           <UserInfoRow label={t('profile.lastActivity')} value={lastLogin} />
           <UserInfoRow label={t('profile.memberSince')} value={created} />
         </View>
-
-        <Button
-          title={t('profile.editProfile')}
-          onPress={() => navigation.navigate(EDIT_PROFILE_SCREEN as never)}
-          size={MEDIUM}
-          style={sg.mT30}
-        />
       </View>
     </ScreenView>
   );

--- a/src/styles/components/ButtonStyle.ts
+++ b/src/styles/components/ButtonStyle.ts
@@ -1,9 +1,9 @@
 import {StyleSheet} from 'react-native';
 
 export const ButtonDimensions = StyleSheet.create({
-  S:{ paddingVertical:8, borderRadius:8, width:120},
-  M:{ paddingVertical:8, paddingHorizontal:16, borderRadius:8},
-  L: { paddingVertical: 12, paddingHorizontal:24, borderRadius:8, width: '100%' },
+  S:{ height: 30, width: "30%"},
+  M:{ height: 40, width: "50%"},
+  L: { height: 40, width: "100%" },
 })
 
 
@@ -12,13 +12,16 @@ const ButtonStyle = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
     flexDirection: 'row',
+    borderRadius:8,
   },
   text: {
     textAlign: 'center',
   },
   content: {
+    flex:1,
     flexDirection: 'row',
     alignItems: 'center',
+    justifyContent: 'center',
     gap: 8,
   },
   iconWrapper: {

--- a/src/styling/buttonUtils.ts
+++ b/src/styling/buttonUtils.ts
@@ -30,7 +30,7 @@ export const getTextColor = (
 export const getFontSize = (size: Size): number => {
   switch (size) {
     case SMALL:
-      return 14;
+      return 13;
     case MEDIUM:
       return 14;
     case LARGE:


### PR DESCRIPTION
- Moved avatar editing logic from ProfileScreen to EditProfileScreen
- ProfileScreen now displays avatar without edit functionality
- Tapping avatar on ProfileScreen navigates to EditProfileScreen
- Added EditableAvatar to EditProfileScreen for image selection
- Improved UX by separating profile viewing and editing concerns